### PR TITLE
Remove deprecated `bottle :unneeded` call (#1) 

### DIFF
--- a/Formula/conftest.rb
+++ b/Formula/conftest.rb
@@ -6,7 +6,6 @@ class Conftest < Formula
   desc "Test your configuration using Open Policy Agent"
   homepage "https://github.com/open-policy-agent/conftest"
   version "0.23.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/open-policy-agent/conftest/releases/download/v0.23.0/conftest_0.23.0_Darwin_x86_64.tar.gz"

--- a/Formula/kubeval.rb
+++ b/Formula/kubeval.rb
@@ -3,7 +3,6 @@ class Kubeval < Formula
   desc "Validate your Kubernetes configurations"
   homepage "https://github.com/instrumenta/kubeval"
   version "0.15.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/instrumenta/kubeval/releases/download/0.15.0/kubeval-darwin-amd64.tar.gz"


### PR DESCRIPTION
Fixes: #2 

* Update kubeval.rb
* Update conftest.rb

Remove `bottle :unneeded` as it is no longer supported per HomeBrew CLI message:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the instrumenta/instrumenta tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/instrumenta/homebrew-instrumenta/Formula/kubeval.rb:6
```

I realize these files aren't supposed to be edited directly, but this could be an intermediate fix if it's easier that doing a new release.