### PR TITLE
Fix: Remove deprecated bottle unneeded

### DIFF
--- a/Formula/conftest.rb
+++ b/Formula/conftest.rb
@@ -6,7 +6,6 @@ class Conftest < Formula
   desc "Test your configuration using Open Policy Agent"
   homepage "https://github.com/open-policy-agent/conftest"
   version "0.23.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/open-policy-agent/conftest/releases/download/v0.23.0/conftest_0.23.0_Darwin_x86_64.tar.gz"

--- a/Formula/kubeval.rb
+++ b/Formula/kubeval.rb
@@ -3,7 +3,6 @@ class Kubeval < Formula
   desc "Validate your Kubernetes configurations"
   homepage "https://github.com/instrumenta/kubeval"
   version "0.15.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/instrumenta/kubeval/releases/download/0.15.0/kubeval-darwin-amd64.tar.gz"


### PR DESCRIPTION
`bottle :unneeded` has been deprecated by brew. No longer needed